### PR TITLE
Update CodePush context hook

### DIFF
--- a/src/contexts/CodePushContext.tsx
+++ b/src/contexts/CodePushContext.tsx
@@ -43,4 +43,10 @@ export const CodePushProvider = ({ children }: { children: ReactNode }) => {
   );
 };
 
-export const useCodePush = () => useContext(CodePushContext);
+export const useCodePush = () => {
+  const context = useContext(CodePushContext);
+  if (context === undefined) {
+    throw new Error('useCodePush must be used within a CodePushProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary
- add runtime error when using `useCodePush` without provider

## Testing
- `npm run eslint` *(fails: Cannot find package 'globals')*
- `npm run jest` *(fails: jest: not found)*
- `npm run build` *(fails: Cannot find package 'globals')*