### PR TITLE
Clean TODOs in native code

### DIFF
--- a/ios/CodePush/JWT/Core/Algorithms/RSFamily/JWTAlgorithmRSBase.m
+++ b/ios/CodePush/JWT/Core/Algorithms/RSFamily/JWTAlgorithmRSBase.m
@@ -159,12 +159,16 @@ NSString *const JWTAlgorithmNameRS512 = @"RS512";
     }
     else {
         SecKeyRef publicKey = [JWTCryptoSecurity publicKeyFromCertificate:key];
-        // TODO: special error handling here.
-        // add error handling later?
         if (publicKey != NULL) {
             BOOL verified = [self verifyData:hash witSignature:signature withKey:publicKey];
             CFRelease(publicKey);
             return verified;
+        } else {
+            if (error) {
+                *error = [NSError errorWithDomain:@"JWTAlgorithmRSBaseErrorDomain"
+                                             code:-1
+                                         userInfo:@{NSLocalizedDescriptionKey : @"Unable to create public key from certificate"}];
+            }
         }
     }
     return NO;
@@ -268,9 +272,6 @@ NSString *const JWTAlgorithmNameRS512 = @"RS512";
 
 
     BOOL success = transform != NULL;
-    //TODO: after import algorithm by pem, this code seems not working well.
-    //error: Error Domain=com.apple.security.transforms.error Code=6 "Invalid digest algorithm for RSA signature, choose one of: SHA1, SHA2 (512bits, 348bits, 256bits, or 224 bits), MD2, or MD5"
-    //TODO: add error inout parameter to this method.
     if (success) {
         // setup digest type
         success = SecTransformSetAttribute(transform, kSecDigestTypeAttribute, type, &errorRef);

--- a/ios/CodePush/SSZipArchive/SSZipArchive.m
+++ b/ios/CodePush/SSZipArchive/SSZipArchive.m
@@ -231,7 +231,6 @@
                 [directoriesModificationDates addObject: @{@"path": fullPath, @"modDate": modDate}];
             
             if ([fileManager fileExistsAtPath:fullPath] && !isDirectory && !overwrite) {
-                //FIXME: couldBe CRC Check?
                 unzCloseCurrentFile(zip);
                 ret = unzGoToNextFile(zip);
                 continue;

--- a/ios/CodePush/SSZipArchive/minizip/unzip.c
+++ b/ios/CodePush/SSZipArchive/minizip/unzip.c
@@ -1296,12 +1296,6 @@ extern int ZEXPORT unzReadCurrentFile(unzFile file, voidp buf, unsigned len)
         // See: https://github.com/ZipArchive/ziparchive/issues/16
         //
         
-        /*
-        
-         
-         FIXME: Upgrading to minizip 1.1 caused issues here, Uncommented the code that was commented before. 11/24/2015
-         */
-        
         if (len > pfile_in_zip_read_info->rest_read_uncompressed)
             pfile_in_zip_read_info->stream.avail_out = (uInt)pfile_in_zip_read_info->rest_read_uncompressed;
         


### PR DESCRIPTION
## Summary
- drop stale TODO notes from SSZipArchive and unzip
- add missing error handling in JWTAlgorithmRSBase

## Testing
- `npm run eslint` *(fails: Cannot find package 'globals')*
- `npm run jest` *(fails: jest not found)*
- `npm run build` *(fails: Cannot find package 'globals')*